### PR TITLE
FR10. Add "Change Password" option in header dropdown

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -74,6 +74,14 @@ export default function Header() {
 										</Link>
 									</DropdownMenuItem>
 
+									<DropdownMenuItem asChild>
+    									<Link href="https://login.wayne.edu/"
+      										target="_blank"
+      										rel="noopener noreferrer">
+      										Change Password
+    									</Link>
+  									</DropdownMenuItem>
+
 									<DropdownMenuSeparator />
 
 									<DropdownMenuItem


### PR DESCRIPTION
Implements FR10 by adding a "Change Password" option to the account dropdown menu.

### Details
- Adds a new dropdown item linking to https://login.wayne.edu/
- Opens in a new tab using target="_blank" and rel="noopener noreferrer"
- Styling remains consistent with existing dropdown items

### Note
We cannot support changing a user’s password directly within StudyRez because authentication is handled through Microsoft/Wayne SSO. Password updates must be done through Wayne’s official login portal.

### Testing
- Verified that "Change Password" appears under the logged-in user dropdown
- Verified that the link opens the Wayne password management page correctly

Closes #37 